### PR TITLE
Feat/docker

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,94 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+logs/*.log
+*.log
+
+# Testing
+.coverage
+.pytest_cache/
+.tox/
+htmlcov/
+
+# Documentation
+docs/
+*.md
+README*
+
+# Temporary files
+temp/
+tmp/
+*.tmp
+*.temp
+
+# Database files (since using cloud postgres)
+*.db
+*.sqlite
+*.sqlite3
+
+# Environment files (will be provided separately)
+.env*
+
+# Package files
+*.tar.gz
+*.zip
+
+# Service temp data
+services/data_service/temp_data/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,31 @@
+# Use Python 3.11 slim as base image
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PATH="/root/.local/bin:$PATH"
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files first for better Docker layer caching
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies using uv
+RUN uv sync --no-dev
+
+# Copy the application code
+COPY . .
+
+# Create logs directory
+RUN mkdir -p logs

--- a/backend/database/functions/get_chart_data.sql
+++ b/backend/database/functions/get_chart_data.sql
@@ -6,59 +6,165 @@ AS $function$
 DECLARE
     result JSONB;
     date_format TEXT;
+    series_interval TEXT;
+    use_hourly_data BOOLEAN;
 BEGIN
-    -- Determine date format based on granularity
+    -- Determine if we need hourly data based on granularity
+    use_hourly_data := p_granularity IN ('hourly', '4hours', '12hours');
+    -- Set date format and series interval
     IF p_granularity = 'monthly' THEN
         date_format := 'YYYY-MM-01';
+        series_interval := '1 day';
     ELSIF p_granularity = 'weekly' THEN
         date_format := 'IYYY-IW'; -- ISO week
-    ELSE
+        series_interval := '1 day';
+    ELSIF p_granularity = 'hourly' THEN
+        date_format := 'YYYY-MM-DD HH24:00';
+        series_interval := '1 hour';
+    ELSIF p_granularity = '4hours' THEN
+        date_format := 'YYYY-MM-DD HH24:00';
+        series_interval := '4 hours';
+    ELSIF p_granularity = '12hours' THEN
+        date_format := 'YYYY-MM-DD HH24:00';
+        series_interval := '12 hours';
+    ELSE -- daily
         date_format := 'YYYY-MM-DD';
+        series_interval := '1 day';
     END IF;
 
     WITH date_series AS (
         SELECT generate_series(
-            TO_DATE(p_start_date, 'YYYY-MM-DD'),
-            TO_DATE(p_end_date, 'YYYY-MM-DD'),
-            '1 day'::interval
-        )::date as day
+            TO_TIMESTAMP(p_start_date || ' 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+            TO_TIMESTAMP(p_end_date || ' 23:59:59', 'YYYY-MM-DD HH24:MI:SS'),
+            series_interval::interval
+        ) as time_point
     ),
     grouped_dates AS (
         SELECT
-            TO_CHAR(day, date_format) as date_group,
-            MIN(day) as start_of_period
+            CASE 
+                WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', time_point), date_format)
+                WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', time_point), date_format)
+                WHEN p_granularity = '4hours' THEN 
+                    TO_CHAR(DATE_TRUNC('hour', time_point) - INTERVAL '1 hour' * (EXTRACT(HOUR FROM time_point)::int % 4), date_format)
+                WHEN p_granularity = '12hours' THEN 
+                    TO_CHAR(DATE_TRUNC('hour', time_point) - INTERVAL '1 hour' * (EXTRACT(HOUR FROM time_point)::int % 12), date_format)
+                WHEN p_granularity = 'hourly' THEN TO_CHAR(DATE_TRUNC('hour', time_point), date_format)
+                ELSE TO_CHAR(DATE_TRUNC('day', time_point), date_format)
+            END as date_group,
+            CASE 
+                WHEN p_granularity = 'monthly' THEN DATE_TRUNC('month', time_point)
+                WHEN p_granularity = 'weekly' THEN DATE_TRUNC('week', time_point)
+                WHEN p_granularity = '4hours' THEN 
+                    DATE_TRUNC('hour', time_point) - INTERVAL '1 hour' * (EXTRACT(HOUR FROM time_point)::int % 4)
+                WHEN p_granularity = '12hours' THEN 
+                    DATE_TRUNC('hour', time_point) - INTERVAL '1 hour' * (EXTRACT(HOUR FROM time_point)::int % 12)
+                WHEN p_granularity = 'hourly' THEN DATE_TRUNC('hour', time_point)
+                ELSE DATE_TRUNC('day', time_point)
+            END as start_of_period
         FROM date_series
-        GROUP BY date_group
+    ),
+    unique_grouped_dates AS (
+        SELECT DISTINCT date_group, start_of_period
+        FROM grouped_dates
     ),
     purchases_by_period AS (
         SELECT
-            TO_CHAR(event_date, date_format) as date_group,
+            CASE 
+                -- For daily/weekly/monthly, use event_date (date field)
+                WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', event_date::timestamp), date_format)
+                WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', event_date::timestamp), date_format)
+                WHEN NOT use_hourly_data THEN TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                -- For hourly granularities, convert string timestamp to timestamp (assuming microseconds since epoch)
+                WHEN p_granularity = '4hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 4), 
+                        date_format
+                    )
+                WHEN p_granularity = '12hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 12), 
+                        date_format
+                    )
+                WHEN p_granularity = 'hourly' THEN 
+                    TO_CHAR(DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)), date_format)
+                ELSE TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+            END as date_group,
             SUM(ecommerce_purchase_revenue) as revenue,
             COUNT(*) as purchases
         FROM purchase
         WHERE tenant_id = p_tenant_id
           AND event_date BETWEEN TO_DATE(p_start_date, 'YYYY-MM-DD') AND TO_DATE(p_end_date, 'YYYY-MM-DD')
           AND (p_location_id IS NULL OR user_prop_default_branch_id = p_location_id)
+          -- Only include records with valid timestamp for hourly data
+          AND (NOT use_hourly_data OR (event_timestamp IS NOT NULL AND event_timestamp ~ '^[0-9]+$'))
         GROUP BY date_group
     ),
     visitors_by_period AS (
         SELECT
-            TO_CHAR(event_date, date_format) as date_group,
+            CASE 
+                -- For daily/weekly/monthly, use event_date (date field)
+                WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', event_date::timestamp), date_format)
+                WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', event_date::timestamp), date_format)
+                WHEN NOT use_hourly_data THEN TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                -- For hourly granularities, convert string timestamp to timestamp
+                WHEN p_granularity = '4hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 4), 
+                        date_format
+                    )
+                WHEN p_granularity = '12hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 12), 
+                        date_format
+                    )
+                WHEN p_granularity = 'hourly' THEN 
+                    TO_CHAR(DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)), date_format)
+                ELSE TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+            END as date_group,
             COUNT(DISTINCT param_ga_session_id) as visitors
         FROM page_view
         WHERE tenant_id = p_tenant_id
           AND event_date BETWEEN TO_DATE(p_start_date, 'YYYY-MM-DD') AND TO_DATE(p_end_date, 'YYYY-MM-DD')
           AND (p_location_id IS NULL OR user_prop_default_branch_id = p_location_id)
+          -- Only include records with valid timestamp for hourly data
+          AND (NOT use_hourly_data OR (event_timestamp IS NOT NULL AND event_timestamp ~ '^[0-9]+$'))
         GROUP BY date_group
     ),
     cart_additions_by_period AS (
         SELECT
-            TO_CHAR(event_date, date_format) as date_group,
+            CASE 
+                -- For daily/weekly/monthly, use event_date (date field)
+                WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', event_date::timestamp), date_format)
+                WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', event_date::timestamp), date_format)
+                WHEN NOT use_hourly_data THEN TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                -- For hourly granularities, convert string timestamp to timestamp
+                WHEN p_granularity = '4hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 4), 
+                        date_format
+                    )
+                WHEN p_granularity = '12hours' THEN 
+                    TO_CHAR(
+                        DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                        INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 12), 
+                        date_format
+                    )
+                WHEN p_granularity = 'hourly' THEN 
+                    TO_CHAR(DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)), date_format)
+                ELSE TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+            END as date_group,
             COUNT(*) as cart_additions
         FROM add_to_cart
         WHERE tenant_id = p_tenant_id
           AND event_date BETWEEN TO_DATE(p_start_date, 'YYYY-MM-DD') AND TO_DATE(p_end_date, 'YYYY-MM-DD')
           AND (p_location_id IS NULL OR user_prop_default_branch_id = p_location_id)
+          -- Only include records with valid timestamp for hourly data
+          AND (NOT use_hourly_data OR (event_timestamp IS NOT NULL AND event_timestamp ~ '^[0-9]+$'))
         GROUP BY date_group
     ),
     searches_by_period AS (
@@ -67,23 +173,69 @@ BEGIN
             SUM(searches) as searches
         FROM (
             SELECT
-                TO_CHAR(event_date, date_format) as date_group,
+                CASE 
+                    -- For daily/weekly/monthly, use event_date (date field)
+                    WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', event_date::timestamp), date_format)
+                    WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', event_date::timestamp), date_format)
+                    WHEN NOT use_hourly_data THEN TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                    -- For hourly granularities, convert string timestamp to timestamp
+                    WHEN p_granularity = '4hours' THEN 
+                        TO_CHAR(
+                            DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                            INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 4), 
+                            date_format
+                        )
+                    WHEN p_granularity = '12hours' THEN 
+                        TO_CHAR(
+                            DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                            INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 12), 
+                            date_format
+                        )
+                    WHEN p_granularity = 'hourly' THEN 
+                        TO_CHAR(DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)), date_format)
+                    ELSE TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                END as date_group,
                 COUNT(*) as searches
             FROM view_search_results
             WHERE tenant_id = p_tenant_id
               AND event_date BETWEEN TO_DATE(p_start_date, 'YYYY-MM-DD') AND TO_DATE(p_end_date, 'YYYY-MM-DD')
               AND (p_location_id IS NULL OR user_prop_default_branch_id = p_location_id)
+              -- Only include records with valid timestamp for hourly data
+              AND (NOT use_hourly_data OR (event_timestamp IS NOT NULL AND event_timestamp ~ '^[0-9]+$'))
             GROUP BY date_group
             
             UNION ALL
             
             SELECT
-                TO_CHAR(event_date, date_format) as date_group,
+                CASE 
+                    -- For daily/weekly/monthly, use event_date (date field)
+                    WHEN p_granularity = 'monthly' THEN TO_CHAR(DATE_TRUNC('month', event_date::timestamp), date_format)
+                    WHEN p_granularity = 'weekly' THEN TO_CHAR(DATE_TRUNC('week', event_date::timestamp), date_format)
+                    WHEN NOT use_hourly_data THEN TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                    -- For hourly granularities, convert string timestamp to timestamp
+                    WHEN p_granularity = '4hours' THEN 
+                        TO_CHAR(
+                            DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                            INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 4), 
+                            date_format
+                        )
+                    WHEN p_granularity = '12hours' THEN 
+                        TO_CHAR(
+                            DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)) - 
+                            INTERVAL '1 hour' * (EXTRACT(HOUR FROM TO_TIMESTAMP(event_timestamp::bigint / 1000000.0))::int % 12), 
+                            date_format
+                        )
+                    WHEN p_granularity = 'hourly' THEN 
+                        TO_CHAR(DATE_TRUNC('hour', TO_TIMESTAMP(event_timestamp::bigint / 1000000.0)), date_format)
+                    ELSE TO_CHAR(DATE_TRUNC('day', event_date::timestamp), date_format)
+                END as date_group,
                 COUNT(*) as searches
             FROM no_search_results
             WHERE tenant_id = p_tenant_id
               AND event_date BETWEEN TO_DATE(p_start_date, 'YYYY-MM-DD') AND TO_DATE(p_end_date, 'YYYY-MM-DD')
               AND (p_location_id IS NULL OR user_prop_default_branch_id = p_location_id)
+              -- Only include records with valid timestamp for hourly data
+              AND (NOT use_hourly_data OR (event_timestamp IS NOT NULL AND event_timestamp ~ '^[0-9]+$'))
             GROUP BY date_group
         ) combined_searches
         GROUP BY date_group
@@ -98,7 +250,7 @@ BEGIN
         'searches', COALESCE(s.searches, 0)
     ) ORDER BY gd.start_of_period)
     INTO result
-    FROM grouped_dates gd
+    FROM unique_grouped_dates gd
     LEFT JOIN purchases_by_period p ON gd.date_group = p.date_group
     LEFT JOIN visitors_by_period v ON gd.date_group = v.date_group
     LEFT JOIN cart_additions_by_period ca ON gd.date_group = ca.date_group

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+
+services:
+  analytics-service:
+    build: .  # Uses shared Dockerfile
+    container_name: analytics-service
+    ports:
+      - "8001:8001"
+    environment:
+      - ENVIRONMENT=DEV
+      - LOG_LEVEL=INFO
+      - PORT=8001
+    env_file:
+      - .env
+    volumes:
+      - ./logs:/app/logs
+    # Different command = different service
+    command: ["uv", "run", "uvicorn", "services.analytics_service.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  auth-service:
+    build: .  # Uses same shared Dockerfile
+    container_name: auth-service
+    ports:
+      - "8003:8003"
+    environment:
+      - ENVIRONMENT=DEV
+      - LOG_LEVEL=INFO
+      - PORT=8003
+    env_file:
+      - .env
+    volumes:
+      - ./logs:/app/logs
+    # Different command = different service
+    command: ["uv", "run", "uvicorn", "services.auth_service.main:app", "--host", "0.0.0.0", "--port", "8003", "--reload"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  data-service:
+    build: .  # Uses same shared Dockerfile  
+    container_name: data-service
+    ports:
+      - "8002:8002"
+    environment:
+      - ENVIRONMENT=DEV
+      - LOG_LEVEL=INFO
+      - PORT=8002
+    env_file:
+      - .env
+    volumes:
+      - ./logs:/app/logs
+    # Different command = different service
+    command: ["uv", "run", "uvicorn", "services.data_service.main:app", "--host", "0.0.0.0", "--port", "8002", "--reload"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+networks:
+  default:
+    name: google-analytics-network
+    driver: bridge

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,20 +5,20 @@ services:
     build: .  # Uses shared Dockerfile
     container_name: analytics-service
     ports:
-      - "8001:8001"
+      - "8002:8002"
     environment:
       - ENVIRONMENT=DEV
       - LOG_LEVEL=INFO
-      - PORT=8001
+      - PORT=8002
     env_file:
       - .env
     volumes:
       - ./logs:/app/logs
     # Different command = different service
-    command: ["uv", "run", "uvicorn", "services.analytics_service.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+    command: ["uv", "run", "uvicorn", "services.analytics_service.main:app", "--host", "0.0.0.0", "--port", "8002", "--reload"]
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -51,20 +51,20 @@ services:
     build: .  # Uses same shared Dockerfile  
     container_name: data-service
     ports:
-      - "8002:8002"
+      - "8001:8001"
     environment:
       - ENVIRONMENT=DEV
       - LOG_LEVEL=INFO
-      - PORT=8002
+      - PORT=8001
     env_file:
       - .env
     volumes:
       - ./logs:/app/logs
     # Different command = different service
-    command: ["uv", "run", "uvicorn", "services.data_service.main:app", "--host", "0.0.0.0", "--port", "8002", "--reload"]
+    command: ["uv", "run", "uvicorn", "services.data_service.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/backend/services/analytics_service/templates/branch_report.html
+++ b/backend/services/analytics_service/templates/branch_report.html
@@ -7,9 +7,9 @@
     <style>
         body { font-family: Arial, sans-serif; font-size: 14px; margin: 0; padding: 20px; background-color: #f8f9fa; color: #333; }
         .container { max-width: 1200px; margin: auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
-        .header { display: flex; flex-direction: column; align-items: flex-start; border-bottom: 2px solid #dee2e6; padding-bottom: 10px; margin-bottom: 20px; }
-        .header h1 { font-size: 24px; margin: 0 0 5px 0; }
-        .header p { font-size: 16px; margin: 0; color: #6c757d; }
+        .header { border-bottom: 2px solid #dee2e6; padding-bottom: 10px; margin-bottom: 20px; overflow: hidden; }
+        .header h1 { font-size: 24px; margin: 0; float: left; }
+        .header p { font-size: 16px; margin: 0; color: #6c757d; float: right; }
         h2 { font-size: 22px; border-bottom: 1px solid #eee; padding-bottom: 5px; margin-top: 30px; }
         h4 { font-size: 18px; margin-top: 20px; margin-bottom: 10px; }
         .table { width: 100%; border-collapse: collapse; }
@@ -183,7 +183,7 @@
                 <thead>
                     <tr>
                         <th>Customer Details</th>
-                        <th>Visited Pages (Top 5 by Base URL)</th>
+                        <th>Viewed Products (Top 5)</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -197,8 +197,10 @@
                         </td>
                         <td>
                             {% if sample.pages_summary %}
-                                {% for page in sample.pages_summary %}
-                                    {{ page.count }}x <a href='{{ page.url }}' target='_blank'>{{ page.title }}</a><br>
+                                {% for product in sample.pages_summary %}
+                                    <a href='{{ product.url }}' target='_blank'>{{ product.title }}</a>
+                                    {% if product.price and product.price > 0 %} - ${{ "%.2f"|format(product.price) }}{% endif %}
+                                    {% if product.category %} ({{ product.category }}){% endif %}<br>
                                 {% endfor %}
                             {% else %}
                                 N/A

--- a/dashboard/src/components/charts/overview-chart.tsx
+++ b/dashboard/src/components/charts/overview-chart.tsx
@@ -40,6 +40,33 @@ export function OverviewChart({ data, dateRange, timeGranularity = "daily" }: Ov
     }
   }
   
+  const formatXAxisLabel = (tickItem: string) => {
+    try {
+      const date = new Date(tickItem)
+      
+      // Check if we're on a smaller screen (simplified responsive check)
+      const isSmallScreen = typeof window !== 'undefined' && window.innerWidth < 768
+      
+      switch (timeGranularity) {
+        case "hourly":
+          return isSmallScreen ? format(date, "HH:mm") : format(date, "MMM d, HH:mm")
+        case "4hours":
+        case "12hours":
+          return isSmallScreen ? format(date, "MMM d\nHH:mm") : format(date, "MMM d, HH:mm")
+        case "weekly":
+          return format(date, "MMM d")
+        case "monthly":
+          return format(date, "MMM yyyy")
+        case "daily":
+        default:
+          return isSmallScreen ? format(date, "M/d") : format(date, "MMM d")
+      }
+    } catch (error) {
+      // Fallback for invalid dates
+      return tickItem
+    }
+  }
+  
   return (
     <Card>
       <CardHeader className="pb-4">
@@ -56,6 +83,7 @@ export function OverviewChart({ data, dateRange, timeGranularity = "daily" }: Ov
                 className="text-xs"
                 tick={{ fill: 'currentColor' }}
                 interval="preserveStartEnd"
+                tickFormatter={formatXAxisLabel}
               />
               <YAxis 
                 className="text-xs"
@@ -68,6 +96,7 @@ export function OverviewChart({ data, dateRange, timeGranularity = "daily" }: Ov
                   borderRadius: '6px',
                   fontSize: '12px'
                 }}
+                labelFormatter={(value) => formatXAxisLabel(value as string)}
               />
               <Legend 
                 wrapperStyle={{ fontSize: '12px' }}


### PR DESCRIPTION
This pull request introduces important improvements to the backend's Docker setup and analytics logic. The main changes include adding Docker support for multiple services, refining the SQL function for chart data to handle new time granularities, and updating the analytics service's reporting logic to match changes in the database schema and data structure.

**Dockerization and Service Orchestration:**

* Added a shared `Dockerfile` for the backend, installing dependencies with `uv` and setting up the environment for Python 3.11.
* Created a `.dockerignore` file to exclude unnecessary files and directories from Docker builds, improving build efficiency.
* Added a `docker-compose.yml` to orchestrate three services (`analytics-service`, `auth-service`, `data-service`) with health checks, environment variables, and shared logging.

**Analytics SQL Function Enhancements:**

* Refactored the `get_chart_data.sql` function to support new time granularities (`hourly`, `4hours`, `12hours`) and improved handling of event timestamps for more accurate grouping and filtering. [[1]](diffhunk://#diff-0940cf82a560cce8c0bb5023c082f8ef1b03dd61fae6c2806edb157299d6e194R9-R167) [[2]](diffhunk://#diff-0940cf82a560cce8c0bb5023c082f8ef1b03dd61fae6c2806edb157299d6e194L70-R238) [[3]](diffhunk://#diff-0940cf82a560cce8c0bb5023c082f8ef1b03dd61fae6c2806edb157299d6e194L101-R253)

**Analytics Service Reporting Logic Updates:**

* Updated the calculation of cart abandonment metrics to use the new `total_value` field and adjusted average value logic.
* Changed repeat visits reporting to use `page_views_count` instead of `pages_viewed` for consistency with updated schema.
* Refactored repeat visit sample transformation to use `products_details` instead of `pages_json`, providing a more accurate summary of top products viewed per session.